### PR TITLE
Add "numberOfImagesToPreLoad" prop for smooth multi-image transitions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ class MyComponent extends React.Component {
 * `infinite`: Boolean, default `true`
   * infinite sliding
 * `lazyLoad`: Boolean, default `false`
-* `preLoad`: Number, default `0`
+* `numberOfImagesToPreLoad`: Number, default `0`
   * If > 0, N extra divs are pre-rendered to support smooth multi-slide transitions
 * `showNav`: Boolean, default `true`
 * `showThumbnails`: Boolean, default `true`

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ class MyComponent extends React.Component {
 * `infinite`: Boolean, default `true`
   * infinite sliding
 * `lazyLoad`: Boolean, default `false`
+* `preLoad`: Number, default `0`
+  * If > 0, N extra divs are pre-rendered to support smooth multi-slide transitions
 * `showNav`: Boolean, default `true`
 * `showThumbnails`: Boolean, default `true`
 * `thumbnailPosition`: String, default `bottom`

--- a/build/image-gallery.js
+++ b/build/image-gallery.js
@@ -674,17 +674,23 @@ var ImageGallery = function (_React$Component) {
       var CENTER = 'center';
       var RIGHT = 'right';
 
-      if (index === currentIndex - 1) {
-        alignment = ' ' + LEFT;
-      } else if (index === currentIndex) {
-        alignment = ' ' + CENTER;
-      } else if (index === currentIndex + 1) {
-        alignment = ' ' + RIGHT;
-      } else if (this.props.numberOfImagesToPreLoad > 0) {
+      if (this.props.numberOfImagesToPreLoad > 0) {
         var preLoadIndex = index - currentIndex;
         if (preLoadIndex > 0 && preLoadIndex <= this.props.numberOfImagesToPreLoad) {
           alignment = ' ' + RIGHT + preLoadIndex;
         }
+      }
+
+      switch (index) {
+        case currentIndex - 1:
+          alignment = ' ' + LEFT;
+          break;
+        case currentIndex:
+          alignment = ' ' + CENTER;
+          break;
+        case currentIndex + 1:
+          alignment = ' ' + RIGHT;
+          break;
       }
 
       if (this.props.items.length >= 3 && this.props.infinite) {

--- a/build/image-gallery.js
+++ b/build/image-gallery.js
@@ -674,16 +674,17 @@ var ImageGallery = function (_React$Component) {
       var CENTER = 'center';
       var RIGHT = 'right';
 
-      switch (index) {
-        case currentIndex - 1:
-          alignment = ' ' + LEFT;
-          break;
-        case currentIndex:
-          alignment = ' ' + CENTER;
-          break;
-        case currentIndex + 1:
-          alignment = ' ' + RIGHT;
-          break;
+      if (index === currentIndex - 1) {
+        alignment = ' ' + LEFT;
+      } else if (index === currentIndex) {
+        alignment = ' ' + CENTER;
+      } else if (index === currentIndex + 1) {
+        alignment = ' ' + RIGHT;
+      } else if (this.props.preLoad > 0) {
+        var preLoadIndex = index - currentIndex;
+        if (preLoadIndex > 0 && preLoadIndex <= this.props.preLoad) {
+          alignment = ' ' + RIGHT + preLoadIndex;
+        }
       }
 
       if (this.props.items.length >= 3 && this.props.infinite) {
@@ -1189,7 +1190,8 @@ ImageGallery.propTypes = {
   renderItem: _propTypes2.default.func,
   stopPropagation: _propTypes2.default.bool,
   additionalClass: _propTypes2.default.string,
-  useTranslate3D: _propTypes2.default.bool
+  useTranslate3D: _propTypes2.default.bool,
+  preLoad: _propTypes2.default.number
 };
 ImageGallery.defaultProps = {
   items: [],
@@ -1218,6 +1220,7 @@ ImageGallery.defaultProps = {
   swipingTransitionDuration: 0,
   slideInterval: 3000,
   swipeThreshold: 30,
+  preLoad: 0,
   renderLeftNav: function renderLeftNav(onClick, disabled) {
     return _react2.default.createElement('button', {
       type: 'button',

--- a/build/image-gallery.js
+++ b/build/image-gallery.js
@@ -680,9 +680,9 @@ var ImageGallery = function (_React$Component) {
         alignment = ' ' + CENTER;
       } else if (index === currentIndex + 1) {
         alignment = ' ' + RIGHT;
-      } else if (this.props.preLoad > 0) {
+      } else if (this.props.numberOfImagesToPreLoad > 0) {
         var preLoadIndex = index - currentIndex;
-        if (preLoadIndex > 0 && preLoadIndex <= this.props.preLoad) {
+        if (preLoadIndex > 0 && preLoadIndex <= this.props.numberOfImagesToPreLoad) {
           alignment = ' ' + RIGHT + preLoadIndex;
         }
       }
@@ -1191,7 +1191,7 @@ ImageGallery.propTypes = {
   stopPropagation: _propTypes2.default.bool,
   additionalClass: _propTypes2.default.string,
   useTranslate3D: _propTypes2.default.bool,
-  preLoad: _propTypes2.default.number
+  numberOfImagesToPreLoad: _propTypes2.default.number
 };
 ImageGallery.defaultProps = {
   items: [],
@@ -1220,7 +1220,7 @@ ImageGallery.defaultProps = {
   swipingTransitionDuration: 0,
   slideInterval: 3000,
   swipeThreshold: 30,
-  preLoad: 0,
+  numberOfImagesToPreLoad: 0,
   renderLeftNav: function renderLeftNav(onClick, disabled) {
     return _react2.default.createElement('button', {
       type: 'button',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image-gallery",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "React carousel image gallery component with thumbnail and mobile support",
   "main": "./build/image-gallery.js",
   "scripts": {

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -87,7 +87,7 @@ export default class ImageGallery extends React.Component {
     stopPropagation: PropTypes.bool,
     additionalClass: PropTypes.string,
     useTranslate3D: PropTypes.bool,
-    preLoad: PropTypes.number,
+    numberOfImagesToPreLoad: PropTypes.number,
   };
 
   static defaultProps = {
@@ -117,7 +117,7 @@ export default class ImageGallery extends React.Component {
     swipingTransitionDuration: 0,
     slideInterval: 3000,
     swipeThreshold: 30,
-    preLoad: 0,
+    numberOfImagesToPreLoad: 0,
     renderLeftNav: (onClick, disabled) => {
       return (
         <button
@@ -660,9 +660,9 @@ export default class ImageGallery extends React.Component {
       alignment = ` ${CENTER}`;
     } else if (index === currentIndex + 1) {
       alignment = ` ${RIGHT}`;
-    } else if (this.props.preLoad > 0) {
+    } else if (this.props.numberOfImagesToPreLoad > 0) {
       const preLoadIndex = index - currentIndex;
-      if (preLoadIndex > 0 && preLoadIndex <= this.props.preLoad) {
+      if (preLoadIndex > 0 && preLoadIndex <= this.props.numberOfImagesToPreLoad) {
         alignment = ` ${RIGHT}${preLoadIndex}`;
       }
     }

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -654,17 +654,23 @@ export default class ImageGallery extends React.Component {
     const CENTER = 'center';
     const RIGHT = 'right';
 
-    if (index === currentIndex - 1) {
-      alignment = ` ${LEFT}`;
-    } else if (index === currentIndex) {
-      alignment = ` ${CENTER}`;
-    } else if (index === currentIndex + 1) {
-      alignment = ` ${RIGHT}`;
-    } else if (this.props.numberOfImagesToPreLoad > 0) {
+    if (this.props.numberOfImagesToPreLoad > 0) {
       const preLoadIndex = index - currentIndex;
       if (preLoadIndex > 0 && preLoadIndex <= this.props.numberOfImagesToPreLoad) {
         alignment = ` ${RIGHT}${preLoadIndex}`;
       }
+    }
+
+    switch (index) {
+      case (currentIndex - 1):
+        alignment = ` ${LEFT}`;
+        break;
+      case (currentIndex):
+        alignment = ` ${CENTER}`;
+        break;
+      case (currentIndex + 1):
+        alignment = ` ${RIGHT}`;
+        break;
     }
 
     if (this.props.items.length >= 3 && this.props.infinite) {

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -87,6 +87,7 @@ export default class ImageGallery extends React.Component {
     stopPropagation: PropTypes.bool,
     additionalClass: PropTypes.string,
     useTranslate3D: PropTypes.bool,
+    preLoad: PropTypes.number,
   };
 
   static defaultProps = {
@@ -116,6 +117,7 @@ export default class ImageGallery extends React.Component {
     swipingTransitionDuration: 0,
     slideInterval: 3000,
     swipeThreshold: 30,
+    preLoad: 0,
     renderLeftNav: (onClick, disabled) => {
       return (
         <button
@@ -652,16 +654,17 @@ export default class ImageGallery extends React.Component {
     const CENTER = 'center';
     const RIGHT = 'right';
 
-    switch (index) {
-      case (currentIndex - 1):
-        alignment = ` ${LEFT}`;
-        break;
-      case (currentIndex):
-        alignment = ` ${CENTER}`;
-        break;
-      case (currentIndex + 1):
-        alignment = ` ${RIGHT}`;
-        break;
+    if (index === currentIndex - 1) {
+      alignment = ` ${LEFT}`;
+    } else if (index === currentIndex) {
+      alignment = ` ${CENTER}`;
+    } else if (index === currentIndex + 1) {
+      alignment = ` ${RIGHT}`;
+    } else if (this.props.preLoad > 0) {
+      const preLoadIndex = index - currentIndex;
+      if (preLoadIndex > 0 && preLoadIndex <= this.props.preLoad) {
+        alignment = ` ${RIGHT}${preLoadIndex}`;
+      }
     }
 
     if (this.props.items.length >= 3 && this.props.infinite) {


### PR DESCRIPTION
[Feature](https://rentpath.atlassian.net/browse/INVP-564)

Solution for https://github.com/xiaolin/react-image-gallery/issues/428

Adds extra "pre-load" divs to the end of the carousel.

Before:

![heKgJszRk4](https://user-images.githubusercontent.com/80267/62794184-0d745080-ba99-11e9-8667-073797f0e4fc.gif)

After:

![dvaC0XzpJx](https://user-images.githubusercontent.com/80267/62794484-d3577e80-ba99-11e9-8fcc-a55a1599b658.gif)

